### PR TITLE
Add Homing Amps

### DIFF
--- a/LowRider CNC/UI V2 LRCNC/config.yaml
+++ b/LowRider CNC/UI V2 LRCNC/config.yaml
@@ -49,6 +49,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -91,6 +92,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -118,6 +120,7 @@ axes:
         cs_pin: i2so.14
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -160,6 +163,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -187,6 +191,7 @@ axes:
         cs_pin: i2so.19
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -228,7 +233,8 @@ axes:
 #        addr: 3
 #        cs_pin: i2so.22
 #        r_sense_ohms: 0.110
-#        run_amps: .1
+#        run_amps: .8
+#        homing_amps: 0.800
 #        hold_amps: 0.050
 #        microsteps: 16
 #        stallguard: 0

--- a/LowRider CNC/UI V3 LRCNC/config.yaml
+++ b/LowRider CNC/UI V3 LRCNC/config.yaml
@@ -49,6 +49,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -91,6 +92,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -118,6 +120,7 @@ axes:
         cs_pin: i2so.14
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -160,6 +163,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -187,6 +191,7 @@ axes:
         cs_pin: i2so.19
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -228,7 +233,8 @@ axes:
 #        addr: 3
 #        cs_pin: i2so.22
 #        r_sense_ohms: 0.110
-#        run_amps: .1
+#        run_amps: 0.800
+#        homing_amps: 0.800
 #        hold_amps: 0.050
 #        microsteps: 16
 #        stallguard: 0

--- a/MPCNC/UI V2 MPCNC/config.yaml
+++ b/MPCNC/UI V2 MPCNC/config.yaml
@@ -49,6 +49,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -76,6 +77,7 @@ axes:
         cs_pin: i2so.14
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -118,6 +120,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -145,6 +148,7 @@ axes:
         cs_pin: i2so.19
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -186,6 +190,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -227,8 +232,9 @@ axes:
 #        addr: 3
 #        cs_pin: i2so.22
 #        r_sense_ohms: 0.110
-#        run_amps: .1000
-#        hold_amps: 0.050
+#        run_amps: 0.800
+#        homing_amps: 0.800
+#        hold_amps: 0.500
 #        microsteps: 16
 #        stallguard: 0
 #        stallguard_debug: false

--- a/MPCNC/UI V3 MPCNC/config.yaml
+++ b/MPCNC/UI V3 MPCNC/config.yaml
@@ -49,6 +49,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -76,6 +77,7 @@ axes:
         cs_pin: i2so.14
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -118,6 +120,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -145,6 +148,7 @@ axes:
         cs_pin: i2so.19
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -186,6 +190,7 @@ axes:
         cs_pin: NO_PIN
         r_sense_ohms: 0.110
         run_amps: 0.800
+        homing_amps: 0.800
         hold_amps: 0.500
         microsteps: 8
         stallguard: 0
@@ -227,8 +232,9 @@ axes:
 #        addr: 3
 #        cs_pin: i2so.22
 #        r_sense_ohms: 0.110
-#        run_amps: .1000
-#        hold_amps: 0.050
+#        run_amps: 0.800
+#        homing_amps: 0.800
+#        hold_amps: 0.500
 #        microsteps: 16
 #        stallguard: 0
 #        stallguard_debug: false


### PR DESCRIPTION
Add Homing Amps to all configs. 
3.7.18 adds this, backwards compatible, just throws an ignore warning.