### PR TITLE
fixes MPCNC Jackpot2 config name field from LowRider to MPCNC

### DIFF
--- a/MPCNC/Jackpot2/JP2_MPCNC/config.yaml
+++ b/MPCNC/Jackpot2/JP2_MPCNC/config.yaml
@@ -1,5 +1,5 @@
 board: Jackpot V2 TMC2226
-name: LowRider
+name: MPCNC
 meta: 07-10-2025 RyanZ
 
 planner_blocks: 32


### PR DESCRIPTION
This updates/fixes the MPCNC Jackpot2 config name field from `LowRider` to `MPCNC`.